### PR TITLE
fix: broken css on faceit blog page and potentially other pages

### DIFF
--- a/src/styles.inject.css
+++ b/src/styles.inject.css
@@ -5,4 +5,5 @@
   --drop-shadow-glow: 0 0 4px var(--color-leetify);
 }
 
-@import "tailwindcss";
+@import "tailwindcss/theme" layer(theme);
+@import "tailwindcss/utilities" layer(utilities);


### PR DESCRIPTION
## Issue

Someone reported an issue that the faceit blog page https://www.faceit.com/en/news/faceit-patch-notes-feb-26 was broken due to this extension. See screenshot bellow

<br />

<img width="777" height="1230" alt="image" src="https://github.com/user-attachments/assets/1ecd0c48-e320-4025-8def-c1b2c12a6b09" />

This PR fixes it.